### PR TITLE
Fix releaser notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Release on GitHub
-    container: forquare/go-cross-builder:1.15.3-6
+    container: forquare/go-cross-builder:1.15.8-7
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         run: goreleaser check --config goreleaser.yml
 
       - name: Release
-        run: goreleaser --config goreleaser.yml
+        run: goreleaser --config goreleaser.yml --release-notes <(github-release-notes -org forquare -repo wave-stamper -since-latest-release -include-author)
         env:
           GITHUB_TOKEN: ${{secrets.RELEASE_TOKEN}}
 


### PR DESCRIPTION
This PR bumps the go-cross-builder that includes [github-release-notes](https://github.com/buchanae/github-release-notes).

It then modifies the use of goreleaser to use this tool to create the release notes so hopefully we don't get any more duplicate notes.